### PR TITLE
adapters: Fix UnityDisplayPowerControl::turn_on memory leak

### DIFF
--- a/src/adapters/unity_display_power_control.cpp
+++ b/src/adapters/unity_display_power_control.cpp
@@ -40,7 +40,7 @@ void repowerd::UnityDisplayPowerControl::turn_on()
 {
     log->log(log_tag, "turn_on()");
 
-    g_dbus_connection_call_sync(
+    auto const reply = g_dbus_connection_call_sync(
         dbus_connection,
         unity_display_bus_name,
         unity_display_object_path,
@@ -52,6 +52,9 @@ void repowerd::UnityDisplayPowerControl::turn_on()
         /* timeout_msec */ 1000,
         nullptr,
         nullptr);
+
+    if (reply)
+        g_variant_unref(reply);
 }
 
 void repowerd::UnityDisplayPowerControl::turn_off()


### PR DESCRIPTION
Fix a memory leak introduced by https://github.com/ubports/repowerd/commit/7689b45b69e53566eb4a48f27cd318de8bd0b724.

g_dbus_connection_call_sync() returns a g_variant which needs to be
unreferenced to release its memory.

Fixes #1 for the vivid branch