### PR TITLE
adapters: Fix crash in UPowerPowerSource's critical temperature assignment

### DIFF
--- a/src/adapters/upower_power_source.cpp
+++ b/src/adapters/upower_power_source.cpp
@@ -54,7 +54,7 @@ double get_critical_temperature(repowerd::DeviceConfig const& device_config)
 try
 {
     auto const ct_str = device_config.get("shutdownBatteryTemperature", "680");
-    return std::stod(ct_str) * 0.1;
+    return ((double)std::stoi(ct_str)) * 0.1;
 }
 catch (...)
 {


### PR DESCRIPTION
Using std::stod when parsing UPower's shutdownBatteryTemperature setting causes repowerd to crash on Sony Xperia X (arm64 kernel).
Use std::stoi instead as the setting itself is backed by an integer type in UPower itself.