### PR TITLE
Use default config from other directory

### DIFF
--- a/src/default_daemon_config.cpp
+++ b/src/default_daemon_config.cpp
@@ -459,9 +459,9 @@ repowerd::DefaultDaemonConfig::the_device_config()
         std::vector<std::string> device_config_dirs{POWERD_DEVICE_CONFIG_DIR};
 
         if (dir_env.empty())
-            device_config_dirs.push_back(REPOWERD_DEVICE_CONFIG_DIR);
+            device_config_dirs.push_front(REPOWERD_DEVICE_CONFIG_DIR);
         else
-            device_config_dirs.push_back(dir_env);
+            device_config_dirs.push_front(dir_env);
 
         device_config = std::make_shared<AndroidDeviceConfig>(
             the_log(),

--- a/src/default_daemon_config.cpp
+++ b/src/default_daemon_config.cpp
@@ -456,12 +456,14 @@ repowerd::DefaultDaemonConfig::the_device_config()
         auto const dir_env_cstr = getenv("REPOWERD_DEVICE_CONFIG_DIR");
         std::string const dir_env{dir_env_cstr ? dir_env_cstr : ""};
 
-        std::vector<std::string> device_config_dirs{POWERD_DEVICE_CONFIG_DIR};
+        std::vector<std::string> device_config_dirs;
 
         if (dir_env.empty())
-            device_config_dirs.push_front(REPOWERD_DEVICE_CONFIG_DIR);
+            device_config_dirs.push_back(REPOWERD_DEVICE_CONFIG_DIR);
         else
-            device_config_dirs.push_front(dir_env);
+            device_config_dirs.push_back(dir_env);
+
+        device_config_dirs.push_back(POWERD_DEVICE_CONFIG_DIR);
 
         device_config = std::make_shared<AndroidDeviceConfig>(
             the_log(),


### PR DESCRIPTION
This is a stupid one: repowerd first looks in powerd folder for default configs, and takes it from there. If then later no device-specific config is found in repowerd folder, it assumes that the default config there is of no use...

Most porters would go to repowerd folder (hence it´s name) for bindmounting the default config only to find out its not working.
 