### PR TITLE
core: actually uses suspend inhibitions in automatic suspend decision

### DIFF
--- a/tests/core-tests/test_system_power_control.cpp
+++ b/tests/core-tests/test_system_power_control.cpp
@@ -85,6 +85,66 @@ TEST_F(ASystemPowerControl,
     expect_automatic_suspend_is_disallowed();
 }
 
+TEST_F(ASystemPowerControl,
+       suspend_inhibition_is_respected_for_automatic_suspend_due_to_inactivity)
+{
+    turn_on_display();
+    client_request_disallow_suspend();
+    advance_time_by(user_inactivity_normal_display_off_timeout);
+
+    expect_automatic_suspend_is_disallowed();
+}
+
+TEST_F(ASystemPowerControl,
+       suspend_inhibition_is_respected_for_automatic_suspend_due_to_power_key)
+{
+    turn_on_display();
+    client_request_disallow_suspend();
+
+    press_power_button();
+    release_power_button();
+
+    expect_automatic_suspend_is_disallowed();
+}
+
+TEST_F(ASystemPowerControl,
+       removal_of_suspend_inhibition_is_respected_for_automatic_suspend_due_to_inactivity)
+{
+    turn_on_display();
+    client_request_disallow_suspend();
+
+    press_power_button();
+    release_power_button();
+
+    client_request_allow_suspend();
+    expect_automatic_suspend_is_allowed();
+}
+
+TEST_F(ASystemPowerControl,
+       removal_of_suspend_inhibition_is_respected_for_automatic_suspend_due_to_power_key)
+{
+    turn_on_display();
+    client_request_disallow_suspend();
+
+    advance_time_by(user_inactivity_normal_display_off_timeout);
+
+    client_request_allow_suspend();
+    expect_automatic_suspend_is_allowed();
+}
+
+TEST_F(ASystemPowerControl,
+       removal_of_suspend_inhibition_has_no_effect_for_automatic_suspend_due_to_proximity)
+{
+    turn_on_display();
+    client_request_disallow_suspend();
+
+    emit_proximity_state_near();
+
+    client_request_allow_suspend();
+
+    expect_automatic_suspend_is_disallowed();
+}
+
 TEST_F(ASystemPowerControl, automatic_suspend_is_disallowed_before_display_is_turned_on)
 {
     testing::InSequence s;


### PR DESCRIPTION
Earlier, I reverted commit 8fd9f6b6a12f ("core: Suspend inhibitions
should affect automatic suspend only when display turns off due to
inactivity"), citing that "On the phone, pressing power button should
respect the suspend blocker."

Well, I was a fool. Reverting that commit does _not_ make it respect to
suspend blockers. Instead, it makes repowerd ignore suspend blockers for
_every cases_, not only in the power button case.

This commit brings back almost everything in that commit back, except
modify it so that it actually respect suspend inhibitions when pressing
power button. Hopefully it'll fix the issue the revert is supposed to
fix.

Fixes https://github.com/ubports/ubuntu-touch/issues/1482