### PR TITLE
Reverse the proximity fake event for the Oneplus One

### DIFF
--- a/src/adapters/android_device_quirks.cpp
+++ b/src/adapters/android_device_quirks.cpp
@@ -49,9 +49,9 @@ repowerd::AndroidDeviceQuirks::ProximityEventType
 synthetic_initial_proximity_event_type_for(std::string device_name)
 {
     // In general we assume a "near" state if we don't get an initial event.
-    // However, arale does not emit an initial event when in the "far" state
+    // However, arale and bacon do not emit an initial event when in the "far" state
     // in particular, so we assume a "far" state for arale.
-    if (device_name == "arale")
+    if (device_name == "arale" || device_name == "bacon" || device_name == "A0001" || device_name == "a0001")
         return repowerd::AndroidDeviceQuirks::ProximityEventType::far;
     else
         return repowerd::AndroidDeviceQuirks::ProximityEventType::near;


### PR DESCRIPTION
As can be seen by the original comment, arale also has this issue. On the Oneplus One it is:

- causing the display to stay off when charging cable is connected or disconnected
- showing a weird off-to-on transition on starting every phone call

It took me years to understand this fully and to find time to dig into this, just saying :)
