### PR TITLE
core: do disallow automatic suspend on client request

### DIFF
--- a/src/core/default_state_machine.cpp
+++ b/src/core/default_state_machine.cpp
@@ -573,6 +573,7 @@ void repowerd::DefaultStateMachine::handle_disallow_suspend()
     log->log(log_tag, "disallow_suspend");
 
     suspend_allowed = false;
+    system_power_control->disallow_automatic_suspend(suspend_id);
 }
 
 void repowerd::DefaultStateMachine::handle_system_resume()

--- a/tests/core-tests/test_system_power_control.cpp
+++ b/tests/core-tests/test_system_power_control.cpp
@@ -155,6 +155,15 @@ TEST_F(ASystemPowerControl, automatic_suspend_is_disallowed_before_display_is_tu
     release_power_button();
 }
 
+TEST_F(ASystemPowerControl, suspend_inhibit_disallow_automatic_suspend_by_itself)
+{
+    testing::InSequence s;
+    expect_automatic_suspend_is_allowed();
+
+    client_request_disallow_suspend();
+    expect_automatic_suspend_is_disallowed();
+}
+
 TEST_F(ASystemPowerControl, system_disallow_suspend_inhibits_suspend_due_to_inactivity)
 {
     turn_on_display();


### PR DESCRIPTION
The phone might be woken up due to other source, and the client may want
the phone to stay awake for a little longer. So, don't assume that we
already disallow it and always disallow automatic suspend when a client
request not to be suspended as it's safe to call the function
repeatedly.

Fixes https://github.com/ubports/ubuntu-touch/issues/1556

(This fixes a critical issue and thus I would like to request a freeze exception.)