### PR TITLE
Log errors in sensorfw plugin load; increase timeout

### DIFF
--- a/src/adapters/sensorfw/sensorfw_common.cpp
+++ b/src/adapters/sensorfw/sensorfw_common.cpp
@@ -95,6 +95,7 @@ const char* repowerd::Sensorfw::plugin_path() const
 bool repowerd::Sensorfw::load_plugin()
 {
     int constexpr timeout_default = 100;
+    GError *err = NULL;
     auto const result =  g_dbus_connection_call_sync(
             dbus_connection,
             dbus_sensorfw_name,
@@ -106,17 +107,19 @@ bool repowerd::Sensorfw::load_plugin()
             G_DBUS_CALL_FLAGS_NONE,
             timeout_default,
             NULL,
-            NULL);
+            &err);
 
-    if (!result)
+    if (err != NULL)
     {
-        log->log(log_tag, "failed to call load_plugin");
+        log->log(log_tag, "failed to call load_plugin: %s", err->message);
+        g_error_free(err);
         return false;
     }
 
     gboolean the_result;
     g_variant_get(result, "(b)", &the_result);
     g_variant_unref(result);
+    g_error_free(err);
 
     return the_result;
 }

--- a/src/adapters/sensorfw/sensorfw_common.cpp
+++ b/src/adapters/sensorfw/sensorfw_common.cpp
@@ -94,7 +94,7 @@ const char* repowerd::Sensorfw::plugin_path() const
 
 bool repowerd::Sensorfw::load_plugin()
 {
-    int constexpr timeout_default = 100;
+    int constexpr timeout_default = 1000;
     GError *err = NULL;
     auto const result =  g_dbus_connection_call_sync(
             dbus_connection,


### PR DESCRIPTION
The loadPlugin call was failing on the PinePhone due to a timeout error. This is likely due to the PinePhone's unfortunate slowness... dbus just couldn't proxy the message fast enough, and sensorfw couldn't answer fast enough.