### PR TITLE
android9: Log errors in sensorfw plugin load; increase timeout

### DIFF
--- a/src/adapters/sensorfw/sensorfw_common.cpp
+++ b/src/adapters/sensorfw/sensorfw_common.cpp
@@ -94,7 +94,7 @@ const char* repowerd::Sensorfw::plugin_path() const
 
 bool repowerd::Sensorfw::load_plugin()
 {
-    int constexpr timeout_default = 100;
+    int constexpr timeout_default = 1000;
     g_autoptr(GError) err = NULL;
     auto const result =  g_dbus_connection_call_sync(
             dbus_connection,

--- a/src/adapters/sensorfw/sensorfw_common.cpp
+++ b/src/adapters/sensorfw/sensorfw_common.cpp
@@ -95,6 +95,7 @@ const char* repowerd::Sensorfw::plugin_path() const
 bool repowerd::Sensorfw::load_plugin()
 {
     int constexpr timeout_default = 100;
+    g_autoptr(GError) err = NULL;
     auto const result =  g_dbus_connection_call_sync(
             dbus_connection,
             dbus_sensorfw_name,
@@ -106,11 +107,12 @@ bool repowerd::Sensorfw::load_plugin()
             G_DBUS_CALL_FLAGS_NONE,
             timeout_default,
             NULL,
-            NULL);
+            &err);
 
-    if (!result)
+    if (err != NULL)
     {
-        log->log(log_tag, "failed to call load_plugin");
+        log->log(log_tag, "failed to call load_plugin: %s", err->message);
+        g_variant_unref(result);
         return false;
     }
 


### PR DESCRIPTION
Retry of https://github.com/ubports/repowerd/pull/24

The loadPlugin call failed due to a timeout error on all android9 devices. Increasing its timeout seems to resolve the issue.

Of course, I couldn't discover this issue without logging the error from the plugin's load.